### PR TITLE
0.4 compat with typealiases and relative paths for loading test data

### DIFF
--- a/src/TradingLogic.jl
+++ b/src/TradingLogic.jl
@@ -4,7 +4,7 @@ else
     using Base.Dates
 end
 
-using Reactive, Match, TimeSeries
+using Reactive, Match, TimeSeries, Compat
 
 module TradingLogic
 
@@ -14,7 +14,7 @@ else
     using Base.Dates
 end
 
-using Reactive, Match, TimeSeries
+using Reactive, Match, TimeSeries, Compat
 
 export runtrading!, runbacktest
 export emptyblotter, printblotter, writeblotter
@@ -59,9 +59,9 @@ the beginning of the trading session).
 
 See `orderhandling!` for the PnL details.
 """
-function runtrading!(blotter::Dict{DateTime,(Int64,Float64)},
+function runtrading!(blotter::Blotter,
                      backtest::Bool,
-                     s_ohlc::Input{(DateTime,Vector{Float64})},
+                     s_ohlc::Input{OHLC},
                      ohlc_inds::Dict{Symbol,Int64},
                      s_pnow::Signal{Float64},
                      position_initial::Int64,
@@ -86,7 +86,7 @@ function runtrading!(blotter::Dict{DateTime,(Int64,Float64)},
                                         position_actual_mut,
                                         order_current,
                                         blotter, backtest),
-    s_target, s_pnow, s_tnow, typ=(Bool,Float64))
+    s_target, s_pnow, s_tnow, typ=@compat(Tuple{Bool,Float64}))
   # error notification
   lift(s -> tradesyserror(s[1]), s_overallstatus, typ=Bool)
 

--- a/src/orderhandl.jl
+++ b/src/orderhandl.jl
@@ -18,7 +18,7 @@ if stop-price of stoplimit order is reached.
 Overwrites `orde` and returns `Bool` request status.
 """
 function targ2order!(orde::Order,
-                     targ::(Int64, Vector{Float64}),
+                     targ::Targ,
                      trig::ASCIIString,
                      position_actual::Int64,
                      backtest::Bool)
@@ -84,11 +84,11 @@ Returns tuple with:
 NOTE: As opposed to `tradeperf` function, here total PnL is updated
 at each price change time-point.
 """
-function orderhandling!(targ::(Int64, Vector{Float64}),
+function orderhandling!(targ::Targ,
                         pnow::Float64, tnow::DateTime,
                         position_actual_mut::Vector{Int64},
                         ordcurr::Order,
-                        blotter::Dict{DateTime,(Int64,Float64)},
+                        blotter::Blotter,
                         backtest::Bool
                         )
   posact = position_actual_mut[1]

--- a/src/strategies/goldencross.jl
+++ b/src/strategies/goldencross.jl
@@ -46,7 +46,7 @@ function goldencrossposlogic(mktstate::Symbol,
 end
 
 "Target signal for goldencross strategy."
-function goldencrosstarget(s_ohlc::Input{(DateTime,Vector{Float64})},
+function goldencrosstarget(s_ohlc::Input{OHLC},
                            ohlc_inds::Dict{Symbol,Int64},
                            position_actual_mut::Vector{Int64},
                            targetqty::Int64,
@@ -56,7 +56,7 @@ function goldencrosstarget(s_ohlc::Input{(DateTime,Vector{Float64})},
   targetqty > 0 || error("target quantity must be positive")
 
   # signals updating at each timestep (aka OHLC bar)
-  buffpclose!(buff::Vector{Float64}, tohlc::(DateTime,Vector{Float64})) =
+  buffpclose!(buff::Vector{Float64}, tohlc::OHLC) =
     sighistbuffer!(buff, tohlc[2][ohlc_inds[:close]])
   pcloseinit = s_ohlc.value[2][ohlc_inds[:close]]
   s_sma_fast = lift(mean,

--- a/src/strategies/luxor.jl
+++ b/src/strategies/luxor.jl
@@ -57,7 +57,7 @@ function luxorposlogic(mktstate::Symbol,
 end
 
 "Target signal for luxor strategy."
-function luxortarget(s_ohlc::Input{(DateTime,Vector{Float64})},
+function luxortarget(s_ohlc::Input{OHLC},
                      ohlc_inds::Dict{Symbol,Int64},
                      position_actual_mut::Vector{Int64},
                      nsma_fast::Int64, nsma_slow::Int64,
@@ -66,7 +66,7 @@ function luxortarget(s_ohlc::Input{(DateTime,Vector{Float64})},
   targetqty > 0 || error("target quantity must be positive")
 
   # signals updating at each timestep (aka OHLC bar)
-  buffpclose!(buff::Vector{Float64}, tohlc::(DateTime,Vector{Float64})) =
+  buffpclose!(buff::Vector{Float64}, tohlc::OHLC) =
     sighistbuffer!(buff, tohlc[2][ohlc_inds[:close]])
   pcloseinit = s_ohlc.value[2][ohlc_inds[:close]]
   s_sma_fast = lift(mean,

--- a/src/types.jl
+++ b/src/types.jl
@@ -46,11 +46,17 @@ function getorderposchg(orde::Order)
   error("Unknown order side")
 end
 
+typealias Blotter @compat Dict{DateTime,Tuple{Int64,Float64}}
+
+typealias Targ @compat Tuple{Int64,Vector{Float64}}
+
+typealias OHLC @compat Tuple{DateTime,Vector{Float64}}
+
 """
 Initialize empty blotter as an associative collection
 `DateTime => (Qty::Int64, FillPrice::Float64)`
 """
-emptyblotter() = (DateTime=>(Int64,Float64))[]
+emptyblotter() = Blotter()
 ### TODO (later): accociative collections syntax changes in Julia 0.4
 
 

--- a/test/backtest.jl
+++ b/test/backtest.jl
@@ -1,13 +1,15 @@
+rel(path::String) = joinpath(splitdir(@__FILE__)[1], path)
+
 facts("OHLC backtest with timearray input") do
   # using quantstrat goldencross test
   #  details in teststrategy_goldencross.jl
   ohlc_BA = TimeSeries.readtimearray(
-    "test/quantstrat/goldencross/data/OHLC_BA_2.csv")
+    rel("quantstrat/goldencross/data/OHLC_BA_2.csv"))
   targetfun = TradingLogic.goldencrosstarget
   mafast = 50; maslow = 200; targetqty = 100
   date_final = Date(2012,8,31)
   ohlc_ta = ohlc_BA[Date(1961,12,31):date_final]
-  ohlc_inds = (Symbol => Int64)[]
+  ohlc_inds = @compat Dict{Symbol,Int64}()
   ohlc_inds[:open] = 1; ohlc_inds[:close] = 4
 
   # quantstrat/goldencross/results_summary.txt
@@ -27,7 +29,7 @@ facts("OHLC backtest with timearray input") do
 
     # quantstrat output: transactions
     txnsdf = DataFrames.readtable(
-      "test/quantstrat/goldencross/transactions.csv",
+      rel("quantstrat/goldencross/transactions.csv"),
       header = true,
       names = [:datestr, :qty, :prc, :fees, :val, :avgcost, :pl],
       eltypes = [UTF8String, Int64, Float64, Float64,
@@ -55,7 +57,7 @@ facts("OHLC backtest with timearray input") do
   end
 
   context("Output file content") do
-    fileout = "backtest_out.csv"
+    fileout = rel("backtest_out.csv")
     dtformat_out = "yyyy-mm-ddTHH:MM:SS"
 
     pnlfin, ddownmax, blotter = TradingLogic.runbacktest(

--- a/test/signals.jl
+++ b/test/signals.jl
@@ -1,3 +1,6 @@
+using TradingLogic
+using Reactive
+
 facts("Working with signals") do
   context("Change detection") do
     s_inp = Reactive.Input(5)

--- a/test/teststrategy_goldencross.jl
+++ b/test/teststrategy_goldencross.jl
@@ -43,7 +43,7 @@ facts("Goldencross strategy backtesting") do
   context("Boeing stock over 50 years vs. quantstrat") do
     # quantstrat input: OHLC data
     ohlc_BA = TimeSeries.readtimearray(
-      "test/quantstrat/goldencross/data/OHLC_BA_2.csv")
+      rel("quantstrat/goldencross/data/OHLC_BA_2.csv"))
     # parameters should match
     #  test/quantstrat/goldencross/quantstrat_goldencross.R
     mafast = 50
@@ -62,7 +62,7 @@ facts("Goldencross strategy backtesting") do
 
     # quantstrat output: transactions
     txnsdf = DataFrames.readtable(
-      "test/quantstrat/goldencross/transactions.csv",
+      rel("quantstrat/goldencross/transactions.csv"),
       header = true,
       names = [:datestr, :qty, :prc, :fees, :val, :avgcost, :pl],
       eltypes = [UTF8String, Int64, Float64, Float64,


### PR DESCRIPTION
I know there is another pull request addressing this but I wanted to show my approach. By creating `typealias`es for Blotter, OHLC and Targ I was able to increase code clarity and cut down on the number of `@compat`s.

I also made the paths to the test data relative, so that `Pkg.test("TradingLogic")` can be run from any directory.
